### PR TITLE
chore: Switch to just one create pr call

### DIFF
--- a/update-bot.sh
+++ b/update-bot.sh
@@ -4,5 +4,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning-gpu --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
+jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning --name gcr.io/jenkinsxio/builder-machine-learning-gpu --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git


### PR DESCRIPTION
This'll keep the resulting `jenkins-x-platform` PR from kicking off three times.

/assign @pmuir